### PR TITLE
make matches call of InputEvent symmetrical

### DIFF
--- a/libevdev/event.py
+++ b/libevdev/event.py
@@ -91,7 +91,7 @@ class InputEvent(object):
                         pass
         """
 
-        if value is not None and self.value != value:
+        if (value is not None and self.value is not None) and self.value != value:
             return False
 
         if isinstance(code, EventType):


### PR DESCRIPTION
When calling `InputEvent(libevdev.foo.bla) in array_of_events`, matches is called from the InputEvent object above.
We need to make the call symmetrical or the above test will fail.
